### PR TITLE
Make nginx config file aside arrow line up with the correct line

### DIFF
--- a/index.html
+++ b/index.html
@@ -7717,7 +7717,7 @@ ubuntu@ubuntu-xenial:~$ sudo nano /etc/nginx/sites-available/default
         Here's the configuration file:
     </p>
 
-    <div class='hang-right-aside-arrow long-arrow' style="margin-top: 702px;"></div>
+    <div class='hang-right-aside-arrow long-arrow' style="margin-top: 777px;"></div>
     <aside class='hang-right-aside aside' style="margin-top: 670px;">
         <h4>Here!</h4>
         <p>


### PR DESCRIPTION
No matter what zoom level I use, the original aside arrow is on the wrong line.  I know this is touchy because it's using margin in pixels, but this new setting makes it line up with the correct line much better than the original, at least on my setup.